### PR TITLE
Update petition.rebuild.sh

### DIFF
--- a/petition.rebuild.sh
+++ b/petition.rebuild.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo "Rebuilding..."
-rm -Rf modules/contrib themes/tao themes/rubik libraries/
+rm -rf modules/contrib themes/tao themes/rubik libraries/
 drush -y make --no-core --contrib-destination=. drupal-org.make


### PR DESCRIPTION
Replaced -R option of rm with the functionally equivalent, but vastly more common -r option. Using the more obscure -R option is confusing, and many people will have to check their man pages to check that it is equivalent to -r. Doing things the obvious way via -r is far more aligned with the principles of software engineering. 
