### PR TITLE
Respect word boundaries in profanity detector

### DIFF
--- a/modules/custom/is_profane/is_profane.module
+++ b/modules/custom/is_profane/is_profane.module
@@ -60,7 +60,7 @@ function is_profane($string, $terms = array()) {
   }
   foreach ($terms as $term) {
     $term = str_replace(',', '', $term);
-    if (strpos($string, $term) !== FALSE) {
+    if (preg_match("/\b$string\b/", $term)) {
       return TRUE;
     }
   }


### PR DESCRIPTION
See #51. This change will avoid a massive number of false positives. The old code would flag anything with the words "classic", "grass", "passion", "assure" and hundreds of other words, because they all contain the substring "ass". I can provide similar lists of non-profane words for other words in the default list of profanities.
