### PR TITLE
Set background-color on .wh-footer

### DIFF
--- a/themes/petitions44/css/style.css
+++ b/themes/petitions44/css/style.css
@@ -262,6 +262,7 @@ body.petition #page-inner {
 /* line 204, ../sass/style.scss */
 #wh-footer {
   background-image: url(../img/wh_home_footer.jpg);
+  background-color: #FFF;
   background-position: 0px 0px;
   position: relative;
 }


### PR DESCRIPTION
Set `background-color: #FFFF;` on `.wh-footer` to prevent the side-bar from being viewed through the footer.
## Before

![image](https://f.cloud.github.com/assets/598803/1424825/ef5a464c-4026-11e3-8017-bd9325c03537.png)
## After

![image](https://f.cloud.github.com/assets/598803/1424844/4c27b602-4027-11e3-87bb-a4f5136b2afc.png)
